### PR TITLE
Swapping naming conventions for gcm_bc_start/endyear with gcm_start/endyear

### DIFF
--- a/pygem_input.py
+++ b/pygem_input.py
@@ -5,7 +5,7 @@ import os
 # External libraries
 import numpy as np
 # Local libaries
-# from pygem.utils._funcs_selectglaciers import get_same_glaciers, glac_num_fromrange, glac_fromcsv, glac_wo_cal
+from pygem.utils._funcs_selectglaciers import get_same_glaciers, glac_num_fromrange, glac_fromcsv, glac_wo_cal
 
 
 #%% ===== MODEL SETUP DIRECTORY =====
@@ -59,21 +59,20 @@ if ref_spinupyears > 0:
 
 # Full GCM period. This includes both the period of time used for bias-correction (e.g., 1981-2019) 
 #   and for the simulation run (e.g., 2000-2100).
-gcm_startyear = 2000            # first year of model run (simulation dataset)
-gcm_endyear = 2100              # last year of model run (simulation dataset)
-gcm_wateryear = 'calendar'      # options for years: 'calendar', 'hydro', 'custom'
-gcm_spinupyears = 0             # spin up years for simulation (output not set up for spinup years at present)
-constantarea_years = 0          # number of years to not let the area or volume change
-if gcm_spinupyears > 0:
-    assert 0==1, 'Code needs to be tested to enure spinup years are correctly accounted for in output files'
-
-# Bias corrected years used for simulation runs. This is the period of time when PyGEM
-#   will actually simulate glacier evolution using the additive (temperature) and 
-#   multiplicative (precip) values calculated using the bias-correction period.
-gcm_bc_startyear = 2000         # first year of bias-correction (simulation dataset)
-gcm_bc_endyear = 2100           # last year of bias-correction (simulation dataset)
+gcm_bc_startyear = 2000            # first year of model run (simulation dataset)
+gcm_bc_endyear = 2100              # last year of model run (simulation dataset)
 gcm_bc_wateryear = 'calendar'      # options for years: 'calendar', 'hydro', 'custom'
 gcm_bc_spinupyears = 0             # spin up years for simulation (output not set up for spinup years at present)
+constantarea_years = 0          # number of years to not let the area or volume change
+if gcm_bc_spinupyears > 0:
+    assert 0==1, 'Code needs to be tested to enure spinup years are correctly accounted for in output files'
+
+# GCM period used for simulation run. This is the period of time when PyGEM
+#   will actually simulate glacier evolution.
+gcm_startyear = 2000         # first year of bias-correction (simulation dataset)
+gcm_endyear = 2100           # last year of bias-correction (simulation dataset)
+gcm_wateryear = 'calendar'      # options for years: 'calendar', 'hydro', 'custom'
+gcm_spinupyears = 0             # spin up years for simulation (output not set up for spinup years at present)
 
 # Hindcast option (flips array so 1960-2000 would run 2000-1960 ensuring that glacier area at 2000 is correct)
 hindcast = False                # True: run hindcast simulation, False: do not
@@ -150,7 +149,7 @@ elif option_calibration in ['MCMC', 'MCMC_fullsim']:
     option_areaconstant = True      # Option to keep area constant or evolve
     # Chain options
     n_chains = 1                    # number of chains (min 1, max 3)
-    mcmc_sample_no = 10000          # number of steps (10000 was found to be sufficient in HMA)
+    mcmc_sample_no = 10000         # number of steps (10000 was found to be sufficient in HMA)
     mcmc_burn_no = 200              # number of steps to burn-in (0 records all steps in chain)
 #    mcmc_sample_no = 100          # number of steps (10000 was found to be sufficient in HMA)
 #    mcmc_burn_no = 0              # number of steps to burn-in (0 records all steps in chain)

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -108,6 +108,10 @@ def getparser():
                         help='realization from large ensemble used for model run (ex. 1011.001 or 1301.020)')
     parser.add_argument('-realization_list', action='store', type=str, default=None,
                         help='text file full of realizations to run')
+    parser.add_argument('-gcm_bc_startyear', action='store', type=int, default=pygem_prms.gcm_bc_startyear,
+                        help='start year for bias correction')
+    parser.add_argument('-gcm_bc_endyear', action='store', type=int, default=pygem_prms.gcm_bc_endyear,
+                        help='start year for bias correction')
     parser.add_argument('-gcm_startyear', action='store', type=int, default=pygem_prms.gcm_startyear,
                         help='start year for the model run')
     parser.add_argument('-gcm_endyear', action='store', type=int, default=pygem_prms.gcm_endyear,
@@ -981,8 +985,8 @@ def main(list_packed_vars):
     
     # ===== TIME PERIOD =====
     dates_table = modelsetup.datesmodelrun(
-            startyear=args.gcm_startyear, endyear=args.gcm_endyear, spinupyears=pygem_prms.gcm_spinupyears,
-            option_wateryear=pygem_prms.gcm_wateryear)
+            startyear=args.gcm_bc_startyear, endyear=args.gcm_bc_endyear, spinupyears=pygem_prms.gcm_bc_spinupyears,
+            option_wateryear=pygem_prms.gcm_bc_wateryear)
     
     # ===== LOAD CLIMATE DATA =====
     # Climate class
@@ -998,14 +1002,14 @@ def main(list_packed_vars):
         # Reference GCM
         ref_gcm = class_climate.GCM(name=pygem_prms.ref_gcm_name)
         # Adjust reference dates in event that reference is longer than GCM data
-        if pygem_prms.ref_startyear >= args.gcm_startyear:
+        if pygem_prms.ref_startyear >= args.gcm_bc_startyear:
             ref_startyear = pygem_prms.ref_startyear
         else:
-            ref_startyear = args.gcm_startyear
-        if pygem_prms.ref_endyear <= args.gcm_endyear:
+            ref_startyear = args.gcm_bc_startyear
+        if pygem_prms.ref_endyear <= args.gcm_bc_endyear:
             ref_endyear = pygem_prms.ref_endyear
         else:
-            ref_endyear = args.gcm_endyear
+            ref_endyear = args.gcm_bc_endyear
         dates_table_ref = modelsetup.datesmodelrun(startyear=ref_startyear, endyear=ref_endyear,
                                                    spinupyears=pygem_prms.ref_spinupyears,
                                                    option_wateryear=pygem_prms.ref_wateryear)
@@ -1109,8 +1113,8 @@ def main(list_packed_vars):
     # reload dates_table for new time period that does not include previous time
     #   period (e.g., 1981-2000)
     dates_table = modelsetup.datesmodelrun(
-            startyear=pygem_prms.gcm_bc_startyear, endyear=pygem_prms.gcm_bc_endyear, spinupyears=pygem_prms.gcm_bc_spinupyears,
-            option_wateryear=pygem_prms.gcm_bc_wateryear)
+            startyear=pygem_prms.gcm_startyear, endyear=pygem_prms.gcm_endyear, spinupyears=pygem_prms.gcm_spinupyears,
+            option_wateryear=pygem_prms.gcm_wateryear)
 
             
     # ===== RUN MASS BALANCE =====
@@ -1394,6 +1398,8 @@ def main(list_packed_vars):
                         
                         # Tidewater glaciers
                         else:
+                            cfg.PARAMS['use_kcalving_for_inversion'] = True
+                            cfg.PARAMS['use_kcalving_for_run'] = True
                             out_calving = find_inversion_calving_from_any_mb(gdir, mb_model=mbmod_inv, mb_years=np.arange(nyears_ref),
                                                                              glen_a=cfg.PARAMS['glen_a']*glen_a_multiplier, fs=fs)
                                 
@@ -1868,25 +1874,25 @@ def main(list_packed_vars):
                             # Filename
                             netcdf_fn = (glacier_str + '_' + gcm_name + '_' + str(pygem_prms.option_calibration) + '_ba' +
                                           str(pygem_prms.option_bias_adjustment) + '_' +  str(sim_iters) + 'sets' + '_' +
-                                          str(args.gcm_startyear) + '_' + str(args.gcm_endyear) + '_all.nc')
+                                          str(args.gcm_bc_startyear) + '_' + str(args.gcm_bc_endyear) + '_all.nc')
                         elif realization is not None:
                             netcdf_fn = (glacier_str + '_' + gcm_name + '_' + scenario + '_' + realization + '_' +
                                           str(pygem_prms.option_calibration) + '_ba' + str(pygem_prms.option_bias_adjustment) + 
-                                          '_' + str(sim_iters) + 'sets' + '_' + str(args.gcm_startyear) + '_' + 
-                                          str(args.gcm_endyear) + '_all.nc')
+                                          '_' + str(sim_iters) + 'sets' + '_' + str(args.gcm_bc_startyear) + '_' + 
+                                          str(args.gcm_bc_endyear) + '_all.nc')
                             np.savetxt(output_sim_fp + 'tas_mon_' + glacier_str + '_' + gcm_name + '_' + scenario + '_' + realization + '_' +
                                           str(pygem_prms.option_calibration) + '_ba' + str(pygem_prms.option_bias_adjustment) + 
-                                          '_' + str(sim_iters) + 'sets' + '_' + str(args.gcm_startyear) + '_' + 
-                                          str(args.gcm_endyear) + '.csv', gcm_temp_adj, delimiter="\n")
+                                          '_' + str(sim_iters) + 'sets' + '_' + str(args.gcm_bc_startyear) + '_' + 
+                                          str(args.gcm_bc_endyear) + '.csv', gcm_temp_adj, delimiter="\n")
                             np.savetxt(output_sim_fp + 'pr_mon_' + glacier_str + '_' + gcm_name + '_' + scenario + '_' + realization + '_' +
                                           str(pygem_prms.option_calibration) + '_ba' + str(pygem_prms.option_bias_adjustment) + 
-                                          '_' + str(sim_iters) + 'sets' + '_' + str(args.gcm_startyear) + '_' + 
-                                          str(args.gcm_endyear) + '.csv', gcm_prec_adj, delimiter="\n")
+                                          '_' + str(sim_iters) + 'sets' + '_' + str(args.gcm_bc_startyear) + '_' + 
+                                          str(args.gcm_bc_endyear) + '.csv', gcm_prec_adj, delimiter="\n")
                         else:
                             netcdf_fn = (glacier_str + '_' + gcm_name + '_' + scenario + '_' +
                                           str(pygem_prms.option_calibration) + '_ba' + str(pygem_prms.option_bias_adjustment) + 
-                                          '_' + str(sim_iters) + 'sets' + '_' + str(args.gcm_startyear) + '_' + 
-                                          str(args.gcm_endyear) + '_all.nc')
+                                          '_' + str(sim_iters) + 'sets' + '_' + str(args.gcm_bc_startyear) + '_' + 
+                                          str(args.gcm_bc_endyear) + '_all.nc')
                         # Export netcdf
                         output_ds_all_stats.to_netcdf(output_sim_fp + netcdf_fn, encoding=encoding) 
                         
@@ -1919,17 +1925,17 @@ def main(list_packed_vars):
                             # Filename
                             netcdf_fn = (glacier_str + '_' + gcm_name + '_' + str(pygem_prms.option_calibration) + '_ba' +
                                           str(pygem_prms.option_bias_adjustment) + '_' +  str(sim_iters) + 'sets' + '_' +
-                                          str(args.gcm_startyear) + '_' + str(args.gcm_endyear) + '_binned.nc')
+                                          str(args.gcm_bc_startyear) + '_' + str(args.gcm_bc_endyear) + '_binned.nc')
                         elif realization is not None:
                             netcdf_fn = (glacier_str + '_' + gcm_name + '_' + scenario + '_' + realization + '_' +
                                           str(pygem_prms.option_calibration) + '_ba' + str(pygem_prms.option_bias_adjustment) + 
-                                          '_' + str(sim_iters) + 'sets' + '_' + str(args.gcm_startyear) + '_' + 
-                                          str(args.gcm_endyear) + '_binned.nc')
+                                          '_' + str(sim_iters) + 'sets' + '_' + str(args.gcm_bc_startyear) + '_' + 
+                                          str(args.gcm_bc_endyear) + '_binned.nc')
                         else:
                             netcdf_fn = (glacier_str + '_' + gcm_name + '_' + scenario + '_' +
                                           str(pygem_prms.option_calibration) + '_ba' + str(pygem_prms.option_bias_adjustment) + 
-                                          '_' + str(sim_iters) + 'sets' + '_' + str(args.gcm_startyear) + '_' + 
-                                          str(args.gcm_endyear) + '_binned.nc')
+                                          '_' + str(sim_iters) + 'sets' + '_' + str(args.gcm_bc_startyear) + '_' + 
+                                          str(args.gcm_bc_endyear) + '_binned.nc')
                         # Export netcdf
                         output_ds_binned_stats.to_netcdf(output_sim_binned_fp + netcdf_fn, encoding=encoding_binned)
             
@@ -1958,12 +1964,12 @@ def main(list_packed_vars):
     #                        # Filename
     #                        netcdf_fn = (glacier_str + '_' + gcm_name + '_' + str(pygem_prms.option_calibration) + '_ba' +
     #                                      str(pygem_prms.option_bias_adjustment) + '_' +  str(sim_iters) + 'sets' + '_' +
-    #                                      str(args.gcm_startyear) + '_' + str(args.gcm_endyear) + '_annual.nc')
+    #                                      str(args.gcm_bc_startyear) + '_' + str(args.gcm_bc_endyear) + '_annual.nc')
     #                    else:
     #                        netcdf_fn = (glacier_str + '_' + gcm_name + '_' + scenario + '_' +
     #                                      str(pygem_prms.option_calibration) + '_ba' + str(pygem_prms.option_bias_adjustment) + 
-    #                                      '_' + str(sim_iters) + 'sets' + '_' + str(args.gcm_startyear) + '_' + 
-    #                                      str(args.gcm_endyear) + '_annual.nc')
+    #                                      '_' + str(sim_iters) + 'sets' + '_' + str(args.gcm_bc_startyear) + '_' + 
+    #                                      str(args.gcm_bc_endyear) + '_annual.nc')
     #                    # Export netcdf
     #                    output_ds_essential_sims.to_netcdf(output_sim_essential_fp + netcdf_fn, encoding=encoding_essential_sims)
     #                    # Close datasets


### PR DESCRIPTION
Modified both pygem_input.py and run_simulation.py to swap naming convention. Simulations run successfully for different bias correction methods and timeframes.