### PR TITLE
Fix to allow for parallelization of grid search for a given glacier

### DIFF
--- a/duplicate_gdirs.py
+++ b/duplicate_gdirs.py
@@ -17,6 +17,7 @@ def main():
 
     if (glac_num is not None) and (num_copies)>1:
         reg,id = glac_num.split('.')
+        reg = reg.zfill(2)
         thous = id[:2]
         
         root = pygem_prms.oggm_gdir_fp

--- a/duplicate_gdirs.py
+++ b/duplicate_gdirs.py
@@ -5,12 +5,12 @@ import pygem_input as pygem_prms
 
 
 def main():
-    parser = argparse.ArgumentParser(description="make duplicate oggm glacier directories")
+    parser = argparse.ArgumentParser(description="Script to make duplicate oggm glacier directories - primarily to avoid corruption if parellelizing runs on a single glacier")
     # add arguments
     parser.add_argument('-rgi_glac_number', type=str, default=None,
                         help='Randoph Glacier Inventory region')
     parser.add_argument('-num_copies', type=int, default=1,
-                        help='Randoph Glacier Inventory region')
+                        help='Number of copies to create of the glacier directory data')
     args = parser.parse_args()
     num_copies = args.num_copies
     glac_num = args.rgi_glac_number

--- a/duplicate_gdirs.py
+++ b/duplicate_gdirs.py
@@ -1,0 +1,35 @@
+import argparse
+import os
+import shutil
+import pygem_input as pygem_prms
+
+
+def main():
+    parser = argparse.ArgumentParser(description="make duplicate oggm glacier directories")
+    # add arguments
+    parser.add_argument('-rgi_glac_number', type=str, default=None,
+                        help='Randoph Glacier Inventory region')
+    parser.add_argument('-num_copies', type=int, default=1,
+                        help='Randoph Glacier Inventory region')
+    args = parser.parse_args()
+    num_copies = args.num_copies
+    glac_num = args.rgi_glac_number
+
+    if (glac_num is not None) and (num_copies)>1:
+        reg,id = glac_num.split('.')
+        thous = id[:2]
+        
+        root = pygem_prms.oggm_gdir_fp
+        sfix = '/per_glacier/' + f'RGI60-{reg}/' + f'RGI60-{reg}.{thous}/'
+
+        for n in range(num_copies):
+            nroot = root.replace('gdirs',f'gdirs_{n+1}')
+            # duplicate strucutre
+            os.makedirs(nroot + sfix + f'RGI60-{reg}.{id}', exist_ok=True)
+            # copy directory data
+            shutil.copytree(root + sfix + f'RGI60-{reg}.{id}', nroot + sfix + f'RGI60-{reg}.{id}', dirs_exist_ok=True)
+
+    return
+
+if __name__ == '__main__':
+    main()

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -134,6 +134,8 @@ def getparser():
                         help='Temperature bias')
     parser.add_argument('-ddfsnow', action='store', type=float, default=pygem_prms.ddfsnow,
                         help='Degree-day factor of snow')
+    parser.add_argument('-gs_job_num', action='store', type=int, default=None,
+                        help='Job number for grid search - sources duplicated oggm glacier directories to avoid corruption')
     # flags
     parser.add_argument('-option_ordered', action='store_true',
                         help='Flag to keep glacier lists ordered (default is off)')
@@ -375,6 +377,11 @@ def main(list_packed_vars):
 
         try:
         # for batman in [0]:
+
+            # if doing grid search - source duplicated oggm gdirs to avoid corruption
+            if not pygem_prms.option_calibration and args.gs_job_num:
+                cfg.PATHS['working_dir'] = pygem_prms.oggm_gdir_fp.replace('gdirs',f'gdirs_{args.gs_job_num}')
+
 
             # ===== Load glacier data: area (km2), ice thickness (m), width (km) =====
             if not glacier_rgi_table['TermType'] in [1,5] or not pygem_prms.include_calving:

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -134,8 +134,8 @@ def getparser():
                         help='Temperature bias')
     parser.add_argument('-ddfsnow', action='store', type=float, default=pygem_prms.ddfsnow,
                         help='Degree-day factor of snow')
-    parser.add_argument('-gs_job_num', action='store', type=int, default=None,
-                        help='Job number for grid search - sources duplicated oggm glacier directories to avoid corruption')
+    parser.add_argument('-oggm_working_dir', action='store', type=int, default=pygem_prms.oggm_gdir_fp,
+                        help='Specify OGGM working dir - useful if performing a grid search and have duplicated glacier directories')
     # flags
     parser.add_argument('-option_ordered', action='store_true',
                         help='Flag to keep glacier lists ordered (default is off)')
@@ -378,19 +378,13 @@ def main(list_packed_vars):
         try:
         # for batman in [0]:
 
-            # if doing grid search - source duplicated oggm gdirs to avoid corruption
-            if not pygem_prms.option_calibration and args.gs_job_num:
-                working_dir = pygem_prms.oggm_gdir_fp.replace('gdirs',f'gdirs_{args.gs_job_num}')
-            else:
-                working_dir = pygem_prms.oggm_gdir_fp
-
             # ===== Load glacier data: area (km2), ice thickness (m), width (km) =====
             if not glacier_rgi_table['TermType'] in [1,5] or not pygem_prms.include_calving:
-                gdir = single_flowline_glacier_directory(glacier_str, logging_level=pygem_prms.logging_level, working_dir=working_dir)
+                gdir = single_flowline_glacier_directory(glacier_str, logging_level=pygem_prms.logging_level, working_dir=args.oggm_working_dir)
                 gdir.is_tidewater = False
                 calving_k = None
             else:
-                gdir = single_flowline_glacier_directory_with_calving(glacier_str, logging_level=pygem_prms.logging_level, working_dir=working_dir)
+                gdir = single_flowline_glacier_directory_with_calving(glacier_str, logging_level=pygem_prms.logging_level, working_dir=args.oggm_working_dir)
                 gdir.is_tidewater = True
                 cfg.PARAMS['use_kcalving_for_inversion'] = True
                 cfg.PARAMS['use_kcalving_for_run'] = True

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -380,16 +380,17 @@ def main(list_packed_vars):
 
             # if doing grid search - source duplicated oggm gdirs to avoid corruption
             if not pygem_prms.option_calibration and args.gs_job_num:
-                cfg.PATHS['working_dir'] = pygem_prms.oggm_gdir_fp.replace('gdirs',f'gdirs_{args.gs_job_num}')
-
+                working_dir = pygem_prms.oggm_gdir_fp.replace('gdirs',f'gdirs_{args.gs_job_num}')
+            else:
+                working_dir = pygem_prms.oggm_gdir_fp
 
             # ===== Load glacier data: area (km2), ice thickness (m), width (km) =====
             if not glacier_rgi_table['TermType'] in [1,5] or not pygem_prms.include_calving:
-                gdir = single_flowline_glacier_directory(glacier_str, logging_level=pygem_prms.logging_level)
+                gdir = single_flowline_glacier_directory(glacier_str, logging_level=pygem_prms.logging_level, working_dir=working_dir)
                 gdir.is_tidewater = False
                 calving_k = None
             else:
-                gdir = single_flowline_glacier_directory_with_calving(glacier_str, logging_level=pygem_prms.logging_level)
+                gdir = single_flowline_glacier_directory_with_calving(glacier_str, logging_level=pygem_prms.logging_level, working_dir=working_dir)
                 gdir.is_tidewater = True
                 cfg.PARAMS['use_kcalving_for_inversion'] = True
                 cfg.PARAMS['use_kcalving_for_run'] = True


### PR DESCRIPTION
Workaround to allow for a single glacier to be run in parallel for different model parameters without corrupting OGGM glacier directory data.  

New script `duplicate_gdirs.py` simply makes N copies of a given glacier directory, keeping the directory structure intact. 
New `oggm_working_dir` CLI argument added to `run_simulation.py`, so that when performing a grid search one can specify an OGGM working directory in a wrapper.