### PR TITLE
Bug fix in obtaining monthly flux divergence in 

### DIFF
--- a/process_bin_monthly_thickness.py
+++ b/process_bin_monthly_thickness.py
@@ -149,8 +149,8 @@ def get_binned_monthly(bin_massbalclim_monthly, bin_massbalclim_annual, bin_mass
 
     ### to get monthly thickness and mass we need monthly flux divergence ###
     # we'll assume the flux divergence is constant througohut the year (is this a good assumption?)
-    # ie. take annual values and divide by 12 - use numpy tile to repeat monthly values by 12 months
-    flux_div_monthly = np.tile(flux_div_annual / 12, 12)
+    # ie. take annual values and divide by 12 - use numpy repeat to repeat values across 12 months
+    flux_div_monthly = np.repeat(flux_div_annual / 12, 12, axis=-1)
 
     # get monthly binned change in thickness assuming constant flux divergence throughout the year
     # account for density contrast (convert monthly climatic mass balance in m w.e. to m ice)

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -1046,6 +1046,8 @@ def main(list_packed_vars):
                                                     gcm_endyear = args.gcm_endyear)
 
                             for n_iter in range(sim_iters):
+                                # pass model params for iteration and update output dataset model params
+                                output_stats.set_modelprms({key: modelprms_all[key][n_iter] for key in modelprms_all})
                                 # create and return xarray dataset
                                 output_stats.create_xr_ds()
                                 output_ds_all_stats = output_stats.get_xr_ds()
@@ -1198,6 +1200,8 @@ def main(list_packed_vars):
                                                     gcm_endyear = args.gcm_endyear)
 
                             for n_iter in range(sim_iters):
+                                # pass model params for iteration and update output dataset model params
+                                output_binned.set_modelprms({key: modelprms_all[key][n_iter] for key in modelprms_all})
                                 # create and return xarray dataset
                                 output_binned.create_xr_ds()
                                 output_ds_binned_stats = output_binned.get_xr_ds()


### PR DESCRIPTION
Minor bug fix in obtaining monthly flux divergence in `process_bin_monthly_thickness.py`

`flux_div_monthly = np.tile(flux_div_annual / 12, 12)` 
changed to:
`flux_div_monthly = np.repeat(flux_div_annual / 12, 12, axis=-1)`