### PR TITLE
run_calibration.py massbalEmulator class object

### DIFF
--- a/run_calibration.py
+++ b/run_calibration.py
@@ -32,12 +32,12 @@ from oggm import workflow
 #from oggm.core.flowline import FluxBasedModel
 #from oggm.core.inversion import calving_flux_from_depth
 
+import torch
+import gpytorch
+import sklearn.model_selection
+
 # Model-specific libraries
-if pygem_prms.option_calibration in ['emulator', 'MCMC']:
-    import torch
-    import gpytorch
-    import sklearn.model_selection
-if pygem_prms.option_calibration in ['MCMC']:
+if 'MCMC' in pygem_prms.option_calibration:
     import pymc
     from pymc import deterministic
 


### PR DESCRIPTION
Implemented a **massbalEmulator**  class object in _run_calibration.py_, cleaning up some redundancy with loading and evaluating the emulator.  Now every call of **run_emulator_mb()** has been replaced by **massbalEmulator.eval()**.

These changes only effect **option_calibration = ['emulator', 'MCMC', 'MCMC_fullsim']**.  Tested and running as expected.