### PR TITLE
compilation of glac_massbaltot_monthly bug fix

### DIFF
--- a/compile_simulations.py
+++ b/compile_simulations.py
@@ -205,7 +205,7 @@ def main(reg, simpath, gcm, scenario, bias_adj, gcm_startyear, gcm_endyear, vars
                         glac_melt_monthly = ds_glac.glac_melt_monthly.values
                         glac_refreeze_monthly = ds_glac.glac_refreeze_monthly.values
                         glac_frontalablation_monthly = ds_glac.glac_frontalablation_monthly.values
-                        glac_massbaltotal_monthly = ds_glac.glac_massbaltotal_monthly.values  * pygem_prms.density_ice
+                        glac_massbaltotal_monthly = ds_glac.glac_massbaltotal_monthly.values
                         glac_prec_monthly = ds_glac.glac_prec_monthly.values
                         glac_mass_monthly = ds_glac.glac_mass_monthly.values
                     except:


### PR DESCRIPTION
PyGEM output `glac_massbaltot_monthly` was being incorrectly converted to mass, but multiplying by density_ice, rather than density_water. Conversion to mass removed, to keep in units of m3 w.e. for consistency with individual components.